### PR TITLE
Set graffiti limit to max 32 characters

### DIFF
--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -4,7 +4,7 @@ exec node /usr/app/node_modules/.bin/lodestar \
     validator \
     --network=mainnet \
     --suggestedFeeRecipient=${FEE_RECIPIENT_ADDRESS} \
-    --graffiti=${GRAFFITI} \
+    --graffiti=${GRAFFITI:0:32} \
     --keymanager true \
     --keymanager.authEnabled false \
     --keymanager.port 3500 \


### PR DESCRIPTION
Even though there is a character limit inside setup wizard, it is possible to get around it when setting graffiti inside config tab of an installed package. If users sets too long graffiti, validator won't start. This PR makes sure that any graffiti longer than 32 character will be cropped to the first 32 characters.