### PR TITLE
Lodestar working on Mainnet with web3signer

### DIFF
--- a/beacon-chain/Dockerfile
+++ b/beacon-chain/Dockerfile
@@ -1,5 +1,5 @@
 ARG UPSTREAM_VERSION
-FROM chainsafe/lodestar:${UPSTREAM_VERSION}
+FROM chainsafe/lodestar:next
 
 COPY jwtsecret.hex /jwtsecret
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/beacon-chain/entrypoint.sh
+++ b/beacon-chain/entrypoint.sh
@@ -12,6 +12,6 @@ exec node /usr/app/node_modules/.bin/lodestar \
     --rest.port ${BEACON_API_PORT} \
     --port $P2P_PORT \
     --logFile /var/lib/data/beacon.log \
-    --logFileLevel ${DEBUG_LEVEL} \
+    --logFileLevel debug \
     --logFileDailyRotate 5 \
     $EXTRA_OPTS

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -1,6 +1,5 @@
 ARG UPSTREAM_VERSION
-FROM chainsafe/lodestar:${UPSTREAM_VERSION}
-
+FROM chainsafe/lodestar:next
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
 ENTRYPOINT ["sh", "-c", "/usr/local/bin/entrypoint.sh"]

--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -10,9 +10,9 @@ exec node /usr/app/node_modules/.bin/lodestar \
     --keymanager.port 3500 \
     --keymanager.address 0.0.0.0 \
     --externalSigner.url=${HTTP_WEB3SIGNER} \
-    --doppelgangerProtectionEnabled \
     --server=${BEACON_NODE_ADDR} \
     --logLevel=${DEBUG_LEVEL} \
-    --logFileLevel=${DEBUG_LEVEL} \
+    --logFileLevel=debug \
+    --logFileDailyRotate 5 \
     --logFile /var/lib/data/validator.log \
     $EXTRA_OPTS


### PR DESCRIPTION
In the current unstable release of Lodestar, the web3signer api works again and I am not officially a Lodestar validator.

`Sep-16 06:12:42.945[]                 info: Published attestations slot=4707061, count=1`

I am keeping this as a draft PR to wait for the official versioned release, so we don't publish a "unstable" build.

Mentioned Web3Signer package has to be merged as well.