### PR TITLE
Update cli args

### DIFF
--- a/beacon-chain/entrypoint.sh
+++ b/beacon-chain/entrypoint.sh
@@ -4,6 +4,7 @@
 exec node /usr/app/node_modules/.bin/lodestar \
     beacon \
     --network=mainnet \
+    --suggestedFeeRecipient=${FEE_RECIPIENT_ADDRESS} \
     --jwt-secret=/jwtsecret \
     --execution.urls=$HTTP_ENGINE \
     --dataDir=/var/lib/data \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       CHECKPOINT_SYNC_URL: ""
       P2P_PORT: 9112
       EXTRA_OPTS: ""
+      FEE_RECIPIENT_ADDRESS: ""
       CONFIG_MODE: basic
   validator:
     image: "validator.lodestar.dnp.dappnode.eth:1.0.0"

--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -83,7 +83,7 @@ fields:
     target:
       type: environment
       name: FEE_RECIPIENT_ADDRESS
-      service: validator
+      service: [validator, beacon-chain]
     title: Fee Recipient Address
     description: >-
       Fee Recipient is a feature that lets you specify a priority fee recipient address on your validator client instance and beacon node. Make sure this is an address you control. After The Merge, Execution Clients will begin depositing priority fees into this address whenever your validator proposes a new block.

--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -12,7 +12,7 @@ exec node /usr/app/node_modules/.bin/lodestar \
     --keymanager.address 0.0.0.0 \
     --externalSigner.url=${HTTP_WEB3SIGNER} \
     --doppelgangerProtectionEnabled \
-    --server=${BEACON_NODE_ADDR} \
+    --beaconNodes=${BEACON_NODE_ADDR} \
     --logLevel=${DEBUG_LEVEL} \
     --logFileLevel=${DEBUG_LEVEL} \
     --logFile /var/lib/data/validator.log \


### PR DESCRIPTION
- Adds suggested fee recipient to beacon node, this will be used as a default for collecting the EL block fees and rewards in case validator fails to update for a validator index before calling produceBlock
- Updates validator beacon node address cli arg, `--server` changed to `--beaconNodes`

@dapplion