### PR TITLE
Align short description with other CLs

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -5,7 +5,7 @@
   "architectures": ["linux/amd64", "linux/arm64"],
   "upstreamRepo": "ChainSafe/lodestar",
   "upstreamArg": "UPSTREAM_VERSION",
-  "shortDescription": "Typescript Ethereum Consensus Layer Implementation by ChainSafe",
+  "shortDescription": "Lodestar ETH2.0 Beacon chain + validator",
   "description": "Typescript Ethereum Consensus Layer Implementation by ChainSafe",
   "type": "service",
   "author": "DAppNode Association <admin@dappnode.io> (https://github.com/dappnode)",


### PR DESCRIPTION
I don't think it is correct to still have `ETH2.0` in the description but on the other hand I think it more important to align this with other CLs and then update the descriptions for all later. This is just to avoid confusion of users who are not that technical.

