### PR TITLE
Increase default memory limit to 8192

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       P2P_PORT: 9112
       EXTRA_OPTS: ""
       FEE_RECIPIENT_ADDRESS: ""
-      MEMORY_LIMIT: 4096
+      MEMORY_LIMIT: 8192
   validator:
     image: "validator.lodestar.dnp.dappnode.eth:0.1.0"
     build:


### PR DESCRIPTION
We have decided to increase the default memory limit to 8GB
- see https://github.com/ChainSafe/lodestar/pull/6343 for rationale